### PR TITLE
Highlight 'lazy' as a keyword

### DIFF
--- a/syntax/reason.vim
+++ b/syntax/reason.vim
@@ -22,7 +22,7 @@ syn match     rustPanic       "\<panic\(\w\)*!" contained
 syn keyword   rustKeyword     box nextgroup=rustBoxPlacement skipwhite skipempty
 syn keyword   rustKeyword     extern nextgroup=rustExternCrate,rustObsoleteExternMod skipwhite skipempty
 " syn keyword   rustKeyword     fun nextgroup=rustFuncName skipwhite skipempty
-syn keyword   rustKeyword     unsafe where while
+syn keyword   rustKeyword     unsafe where while lazy
 syn keyword   rustStorage     and class constraint exception external include inherit let method module nonrec open private rec type val with
 " FIXME: Scoped impl's name is also fallen in this category
 " syn keyword   rustStorageIdent   let and module type nextgroup=rustIdentifier skipwhite skipempty


### PR DESCRIPTION
`lazy` is a keyword, as found in the parser: https://github.com/facebook/reason/blob/985f28150026fb3ce353c699a2a0cbc9a52de919/src/reason-parser/reason_parser.mly#L4267