### PR TITLE
Fix variant highlighting

### DIFF
--- a/syntax/reason.vim
+++ b/syntax/reason.vim
@@ -38,7 +38,7 @@ syn match     rustFuncName    "\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%
 syn match labelArgument "\(\l\|_\)\(\w\|'\)*::\(?\)\?"lc=0   "Allows any space between label name and ::
 syn match labelArgumentPunned "::\(?\)\?\(\l\|_\)\(\w\|'\)*"lc=0   "Allows any space between label name and ::
 
-syn match    rustEnumVariant  "\<\u\(\w\|'\)*\>[^\.]"me=e-1
+syn match    rustEnumVariant  "\<\u\(\w\|'\)*\>"
 " Polymorphic variants
 syn match    rustEnumVariant  "`\w\(\w\|'\)*\>"
 


### PR DESCRIPTION
If a variant constructor is on its own line, didn't have an argument, and wasn't in the last position, it wouldn't receive highlighting.
This hopefully fixes that.
Example: 'A' wouldn't receive highlighting
type t = 
  | A
  | B(int)
  | C